### PR TITLE
22 core edge 등록 핸들링 및 message 중복 필터링 등

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ctest:*)",
+      "Bash(cmake --build broker/build)"
+    ]
+  }
+}

--- a/broker/CMakeLists.txt
+++ b/broker/CMakeLists.txt
@@ -62,3 +62,7 @@ enable_testing()
 add_executable(test_json test/test_json.cpp)
 target_link_libraries(test_json PRIVATE broker_common)
 add_test(NAME test_json COMMAND test_json)
+
+add_executable(test_core_logic test/test_core_logic.cpp)
+target_link_libraries(test_core_logic PRIVATE broker_common)
+add_test(NAME test_core_logic COMMAND test_core_logic)

--- a/broker/include/core_helpers.h
+++ b/broker/include/core_helpers.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+// Parse "ip:port" string (stored in MqttMessage::payload.description for edge registration)
+// Returns false if format is invalid or port is out of range
+inline bool parse_ip_port(const char* desc, char* ip_out, size_t ip_len, int* port_out) {
+    char ip_buf[64] = {};
+    int  port = 0;
+    if (sscanf(desc, "%63[^:]:%d", ip_buf, &port) != 2) return false;
+    if (port <= 0 || port > 65535) return false;
+    snprintf(ip_out, ip_len, "%s", ip_buf);
+    *port_out = port;
+    return true;
+}

--- a/broker/include/core_helpers.h
+++ b/broker/include/core_helpers.h
@@ -15,3 +15,8 @@ inline bool parse_ip_port(const char* desc, char* ip_out, size_t ip_len, int* po
     *port_out = port;
     return true;
 }
+
+// Build an alert topic: "<prefix>/<id>"  e.g. "campus/alert/node_down/<uuid>"
+inline void make_alert_topic(const char* prefix, const char* id, char* buf, size_t len) {
+    snprintf(buf, len, "%s/%s", prefix, id);
+}

--- a/broker/src/core/main.cpp
+++ b/broker/src/core/main.cpp
@@ -170,7 +170,10 @@ int main(int argc, char* argv[]) {
     }
 
     // 3. mosquitto 클라이언트 생성
-    CoreContext ctx = { core_id, &ct_manager };
+    CoreContext ctx;
+    ctx.core_id = core_id;
+    ctx.ct_manager = &ct_manager;
+
     struct mosquitto* mosq = mosquitto_new(core_id, true, &ctx);
     if (!mosq) {
         fprintf(stderr, "[core] mosquitto_new failed\n");

--- a/broker/src/core/main.cpp
+++ b/broker/src/core/main.cpp
@@ -108,12 +108,30 @@ static void on_message(struct mosquitto* mosq, void* userdata,
             node.id, node_ip, node_port, ct.version);
         return;
     }
+
+    // 이벤트 데이터 / Relay (FR-02, FR-03): msg_id 중복 필터 후 republish
+    if (strncmp(msg->topic, "campus/data/", 12) == 0 ||
+        strncmp(msg->topic, "campus/relay/", 13) == 0) {
+        MqttMessage evt;
+        std::string json(static_cast<char*>(msg->payload), msg->payloadlen);
+        if (!mqtt_message_from_json(json, evt)) return;
+
+        std::string msg_id(evt.msg_id);
+        if (ctx->seen_msg_ids.count(msg_id)) return;
+
+        if (ctx->seen_msg_ids.size() > 10000) ctx->seen_msg_ids.clear();
+        ctx->seen_msg_ids.insert(msg_id);
+
+        mosquitto_publish(mosq, nullptr, msg->topic,
+            msg->payloadlen, msg->payload, 1, false);
+        printf("[core] event forwarded: %s  (msg_id=%.8s)\n", msg->topic, evt.msg_id);
+        return;
+    }
+
     // Core 간 CT 동기화 (C-01) — TODO: peer CT merge
     if (strcmp(msg->topic, TOPIC_CT_SYNC) == 0) {
         return;
     }
-
-    // 이벤트 데이터 / Relay — TODO: msg_id 중복 필터링 후 Client 전달
 }
 
 // main =====================================================

--- a/broker/src/core/main.cpp
+++ b/broker/src/core/main.cpp
@@ -10,13 +10,14 @@
 #include "mqtt_json.h"
 #include "message.h"
 #include "uuid.h"
+#include "core_helpers.h"
 
 // Global State =====================================================
 static volatile bool g_running = true;
 
 struct CoreContext {
-    const char*                     core_id;
-    ConnectionTableManager*         ct_manager;
+    const char* core_id;
+    ConnectionTableManager* ct_manager;
     std::unordered_set<std::string> seen_msg_ids;
 };
 

--- a/broker/src/core/main.cpp
+++ b/broker/src/core/main.cpp
@@ -58,7 +58,7 @@ static void on_message(struct mosquitto* mosq, void* userdata,
     const struct mosquitto_message* msg) {
     auto* ctx = static_cast<CoreContext*>(userdata);
 
-    // Node 비정상 종료 LWT (W-02): OFFLINE 마킹 후 CT 브로드캐스트
+    // Node 비정상 종료 LWT (W-02): OFFLINE 마킹 → CT 브로드캐스트 → node_down 알림 (FR-06)
     if (strncmp(msg->topic, "campus/will/node/", 17) == 0) {
         const char* node_id = msg->topic + 17;
         if (ctx->ct_manager->setNodeStatus(node_id, NODE_STATUS_OFFLINE)) {
@@ -66,6 +66,12 @@ static void on_message(struct mosquitto* mosq, void* userdata,
             std::string json = connection_table_to_json(ct);
             mosquitto_publish(mosq, nullptr, TOPIC_TOPOLOGY,
                 (int)json.size(), json.c_str(), 1, true);
+
+            char alert_topic[128];
+            snprintf(alert_topic, sizeof(alert_topic), "campus/alert/node_down/%s", node_id);
+            mosquitto_publish(mosq, nullptr, alert_topic,
+                (int)json.size(), json.c_str(), 1, false);
+
             printf("[core] node offline: %s  (ct.version=%d)\n", node_id, ct.version);
         }
         return;

--- a/broker/src/core/main.cpp
+++ b/broker/src/core/main.cpp
@@ -3,6 +3,8 @@
 #include <cstdlib>
 #include <csignal>
 #include <ctime>
+#include <string>
+#include <unordered_set>
 #include <mosquitto.h>
 #include "connection_table_manager.h"
 #include "mqtt_json.h"
@@ -13,8 +15,9 @@
 static volatile bool g_running = true;
 
 struct CoreContext {
-    const char* core_id;
-    ConnectionTableManager* ct_manager;
+    const char*                     core_id;
+    ConnectionTableManager*         ct_manager;
+    std::unordered_set<std::string> seen_msg_ids;
 };
 
 static void handle_signal(int) { g_running = false; }

--- a/broker/src/core/main.cpp
+++ b/broker/src/core/main.cpp
@@ -78,6 +78,36 @@ static void on_message(struct mosquitto* mosq, void* userdata,
         return;
     }
 
+    // Edge 등록 (M-03): CT에 추가 후 브로드캐스트
+    if (strncmp(msg->topic, "campus/monitor/status/", 22) == 0) {
+        MqttMessage reg;
+        std::string json(static_cast<char*>(msg->payload), msg->payloadlen);
+        if (!mqtt_message_from_json(json, reg)) return;
+
+        char node_ip[IP_LEN] = {};
+        int  node_port = 0;
+        if (!parse_ip_port(reg.payload.description, node_ip, sizeof(node_ip), &node_port)) {
+            fprintf(stderr, "[core] bad status description: '%s'\n", reg.payload.description);
+            return;
+        }
+
+        NodeEntry node = {};
+        strncpy(node.id, reg.source.id, UUID_LEN - 1);
+        node.role = NODE_ROLE_NODE;
+        strncpy(node.ip, node_ip, IP_LEN - 1);
+        node.port = (uint16_t)node_port;
+        node.status = NODE_STATUS_ONLINE;
+        node.hop_to_core = 1;
+
+        ctx->ct_manager->addNode(node);
+        ConnectionTable ct = ctx->ct_manager->snapshot();
+        std::string ct_json = connection_table_to_json(ct);
+        mosquitto_publish(mosq, nullptr, TOPIC_TOPOLOGY,
+            (int)ct_json.size(), ct_json.c_str(), 1, true);
+        printf("[core] edge registered: %s  %s:%d  (ct.version=%d)\n",
+            node.id, node_ip, node_port, ct.version);
+        return;
+    }
     // Core 간 CT 동기화 (C-01) — TODO: peer CT merge
     if (strcmp(msg->topic, TOPIC_CT_SYNC) == 0) {
         return;

--- a/broker/test/test_core_logic.cpp
+++ b/broker/test/test_core_logic.cpp
@@ -1,0 +1,218 @@
+// test_core_logic.cpp
+// Core 로직 단위 테스트: parse_ip_port, make_alert_topic, msg_id 중복 필터
+//
+// 외부 프레임워크 없음 — 빌드 후 ./build/test_core_logic 으로 실행
+
+#include <cstdio>
+#include <cstring>
+#include <cmath>
+#include <string>
+#include <unordered_set>
+#include "core_helpers.h"
+#include "mqtt_json.h"
+
+// ── 미니 테스트 러너 ──────────────────────────────────────────────────────────
+
+static int  g_pass = 0;
+static int  g_fail = 0;
+static bool g_test_ok = true;
+
+static void begin_test(const char* name) {
+    g_test_ok = true;
+    printf("[ RUN  ] %s\n", name);
+}
+
+#define CHECK(expr) \
+    do { \
+        if (!(expr)) { \
+            g_fail++; g_test_ok = false; \
+            fprintf(stderr, "        FAIL  %s:%d  (%s)\n", __FILE__, __LINE__, #expr); \
+        } else { \
+            g_pass++; \
+        } \
+    } while (0)
+
+#define CHECK_EQ(a, b)    CHECK((a) == (b))
+#define CHECK_STREQ(a, b) CHECK(std::strcmp((a), (b)) == 0)
+#define CHECK_TRUE(e)     CHECK(e)
+#define CHECK_FALSE(e)    CHECK(!(e))
+
+static void end_test(const char* name) {
+    printf("[  %s ] %s\n\n", g_test_ok ? " OK " : "FAIL", name);
+}
+
+// ── 테스트 상수 ───────────────────────────────────────────────────────────────
+
+#define NODE_1  "cccccccc-0000-0000-0000-000000000003"
+#define MSG_EVT "550e8400-e29b-41d4-a716-446655440000"
+
+// ── TC-01: parse_ip_port 정상 케이스 ─────────────────────────────────────────
+
+static void tc_parse_ip_port_normal() {
+    begin_test("TC-01: parse_ip_port — 정상 케이스");
+
+    char ip[64] = {};
+    int  port = 0;
+
+    CHECK_TRUE(parse_ip_port("192.168.1.10:1884", ip, sizeof(ip), &port));
+    CHECK_STREQ(ip, "192.168.1.10");
+    CHECK_EQ(port, 1884);
+
+    port = 0;
+    memset(ip, 0, sizeof(ip));
+    CHECK_TRUE(parse_ip_port("127.0.0.1:1883", ip, sizeof(ip), &port));
+    CHECK_STREQ(ip, "127.0.0.1");
+    CHECK_EQ(port, 1883);
+
+    port = 0;
+    memset(ip, 0, sizeof(ip));
+    CHECK_TRUE(parse_ip_port("10.0.0.1:9001", ip, sizeof(ip), &port));
+    CHECK_STREQ(ip, "10.0.0.1");
+    CHECK_EQ(port, 9001);
+
+    end_test("TC-01: parse_ip_port — 정상 케이스");
+}
+
+// ── TC-02: parse_ip_port 비정상 케이스 ───────────────────────────────────────
+
+static void tc_parse_ip_port_invalid() {
+    begin_test("TC-02: parse_ip_port — 비정상 케이스");
+
+    char ip[64] = {};
+    int  port = 0;
+
+    // 콜론 없음
+    CHECK_FALSE(parse_ip_port("badstring", ip, sizeof(ip), &port));
+
+    // 포트만 있고 ip 없음
+    CHECK_FALSE(parse_ip_port(":1883", ip, sizeof(ip), &port));
+
+    // 포트 0 (범위 밖)
+    CHECK_FALSE(parse_ip_port("127.0.0.1:0", ip, sizeof(ip), &port));
+
+    // 포트 65536 (범위 밖)
+    CHECK_FALSE(parse_ip_port("127.0.0.1:65536", ip, sizeof(ip), &port));
+
+    // 빈 문자열
+    CHECK_FALSE(parse_ip_port("", ip, sizeof(ip), &port));
+
+    end_test("TC-02: parse_ip_port — 비정상 케이스");
+}
+
+// ── TC-03: make_alert_topic ───────────────────────────────────────────────────
+
+static void tc_make_alert_topic() {
+    begin_test("TC-03: make_alert_topic");
+
+    char buf[128] = {};
+
+    make_alert_topic("campus/alert/node_down", NODE_1, buf, sizeof(buf));
+    CHECK_STREQ(buf, "campus/alert/node_down/" NODE_1);
+
+    make_alert_topic("campus/alert/node_up", NODE_1, buf, sizeof(buf));
+    CHECK_STREQ(buf, "campus/alert/node_up/" NODE_1);
+
+    end_test("TC-03: make_alert_topic");
+}
+
+// ── TC-04: msg_id 중복 필터 — 기본 동작 ──────────────────────────────────────
+
+static void tc_dedup_basic() {
+    begin_test("TC-04: msg_id dedup — 기본 동작");
+
+    std::unordered_set<std::string> seen;
+
+    // 첫 삽입: 새로운 msg_id
+    std::string id1 = MSG_EVT;
+    CHECK_TRUE(seen.count(id1) == 0);
+    seen.insert(id1);
+    CHECK_EQ((int)seen.size(), 1);
+
+    // 두 번째: 중복
+    CHECK_TRUE(seen.count(id1) != 0);
+
+    // 다른 id는 통과
+    std::string id2 = "ffffffff-ffff-4fff-bfff-ffffffffffff";
+    CHECK_TRUE(seen.count(id2) == 0);
+    seen.insert(id2);
+    CHECK_EQ((int)seen.size(), 2);
+
+    end_test("TC-04: msg_id dedup — 기본 동작");
+}
+
+// ── TC-05: msg_id seen_set 용량 제한 ─────────────────────────────────────────
+
+static void tc_dedup_cap() {
+    begin_test("TC-05: seen_msg_ids cap — 10001개 삽입 후 clear");
+
+    std::unordered_set<std::string> seen;
+    char buf[64];
+
+    for (int i = 0; i <= 10000; i++) {
+        snprintf(buf, sizeof(buf), "msg-%05d", i);
+        seen.insert(std::string(buf));
+    }
+    CHECK_EQ((int)seen.size(), 10001);
+
+    // 용량 초과 시 clear (core/main.cpp 로직과 동일)
+    if (seen.size() > 10000) seen.clear();
+    CHECK_EQ((int)seen.size(), 0);
+
+    // clear 후 재삽입 정상 동작 확인
+    seen.insert("msg-new");
+    CHECK_EQ((int)seen.size(), 1);
+
+    end_test("TC-05: seen_msg_ids cap — 10001개 삽입 후 clear");
+}
+
+// ── TC-06: Edge 등록 메시지 round-trip ───────────────────────────────────────
+// Edge on_connect_core 가 발행하는 STATUS JSON 을 파싱해 description → ip:port 추출
+
+static void tc_edge_registration_roundtrip() {
+    begin_test("TC-06: Edge 등록 STATUS JSON round-trip");
+
+    // Edge 가 실제로 publish 하는 것과 동일한 형식의 JSON
+    const char* status_json =
+        "{"
+        "\"msg_id\":\"" MSG_EVT "\","
+        "\"type\":\"STATUS\","
+        "\"timestamp\":\"2026-04-16T00:00:00Z\","
+        "\"source\":{\"role\":\"NODE\",\"id\":\"" NODE_1 "\"},"
+        "\"target\":{\"role\":\"CORE\",\"id\":\"\"},"
+        "\"route\":{\"original_node\":\"\",\"prev_hop\":\"\",\"next_hop\":\"\","
+        "           \"hop_count\":0,\"ttl\":0},"
+        "\"delivery\":{\"qos\":1,\"dup\":false,\"retain\":false},"
+        "\"payload\":{\"building_id\":\"\",\"camera_id\":\"\","
+        "             \"description\":\"10.0.0.5:1884\"}"
+        "}";
+
+    MqttMessage reg = {};
+    CHECK_TRUE(mqtt_message_from_json(std::string(status_json), reg));
+    CHECK_EQ(reg.type, MSG_TYPE_STATUS);
+    CHECK_STREQ(reg.source.id, NODE_1);
+
+    // description 에서 ip:port 파싱
+    char ip[64] = {};
+    int  port = 0;
+    CHECK_TRUE(parse_ip_port(reg.payload.description, ip, sizeof(ip), &port));
+    CHECK_STREQ(ip, "10.0.0.5");
+    CHECK_EQ(port, 1884);
+
+    end_test("TC-06: Edge 등록 STATUS JSON round-trip");
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+
+int main() {
+    tc_parse_ip_port_normal();
+    tc_parse_ip_port_invalid();
+    tc_make_alert_topic();
+    tc_dedup_basic();
+    tc_dedup_cap();
+    tc_edge_registration_roundtrip();
+
+    printf("══════════════════════════════════════\n");
+    printf("  결과: %d passed, %d failed\n", g_pass, g_fail);
+    printf("══════════════════════════════════════\n");
+    return g_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
### 작업 내용

1. Edge 접속 시 등록 핸들러 작성
2. `unordered_set` 으로 메시지 중복 제거 로직 추가
3. `core_helpers.h`에 헬퍼함수 작성 (ip:port 파싱, alert 메시지 조립 헬퍼)
4. 테스트 케이스 작성 (메시지 중복 필터링, Edge 등록 메시지 시뮬레이션 등)