### PR TITLE
[feat] Core 미완료 항목 구현 및 PRD 설계 제약 문서화

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -459,7 +459,7 @@ typedef struct {
 
 ---
 
-## 14. 현재 개발 진행도 (2026-04-16 기준)
+## 14. 현재 개발 진행도 (2026-04-17 기준)
 
 ### 14.1 구현 완료 항목
 
@@ -491,6 +491,9 @@ typedef struct {
 | CT 양방향 동기화: TOPIC_CT_SYNC(Active→Backup, retained), TOPIC_NODE_REGISTER(Backup→Active) | FR-01, C-01 |
 | Backup mosq_peer — Active 브로커 연결, merge_connection_tables() (변경 시만 재발행) | FR-01, C-01 |
 | Backup: Active LWT 수신 → `campus/alert/core_switch` 발행 (자신 IP:Port 포함) | FR-05, FR-14, A-03 |
+| CT 수신 시 version 비교 → 구버전 무시 (`on_message`, `on_message_peer`) | FR-01 |
+| Node 복구(OFFLINE→ONLINE) 감지 → `campus/alert/node_up/<id>` 발행 | FR-13, A-02 |
+| Core Election — `_core/election/request` 투표, `_core/election/result` 집계 → ACTIVE 전환 | FR-10, C-03, C-04 |
 
 #### Edge Broker (`broker/src/edge/main.cpp`)
 
@@ -498,7 +501,7 @@ typedef struct {
 | -------- | --------------- |
 | UUID 자동 생성 (edge_id), outbound IP 자동 감지 (UDP SOCK_DGRAM) | — |
 | mosq_core — Active Core 연결, LWT(W-02) 설정, 등록(M-03) publish | W-02, 5.3 |
-| CT(M-04) 수신 → 로컬 CT 갱신 | M-04 |
+| CT(M-04) 수신 → version 비교 후 구버전 무시, 최신 CT를 `ct_manager`에 반영 | M-04, FR-01, FR-09 |
 | Ping/Pong 응답 (M-01/M-02) | M-01, M-02 |
 | mosq_local — 로컬 CCTV `campus/data/#` 구독, build_event_message() (타입·우선순위 자동 추론) | FR-01 |
 | mosq_backup — Backup Core 선택적 연결 (`[backup_core_ip] [backup_core_port]`) | FR-05 |
@@ -526,16 +529,15 @@ typedef struct {
 
 | 구성요소 | 관련 FR | 비고 |
 | -------- | ------- | ---- |
-| Node 복구 시 `campus/alert/node_up/<id>` 발행 | FR-13, A-02 | LWT에는 복구 감지 없음 — 별도 STATUS heartbeat 필요 |
-| CT 수신 시 version 비교 → 구버전 무시 | FR-01 | mosq_peer on_message_peer 에 TODO |
-| Core Election 메커니즘 (`_core/election/#`) | FR-10 | Phase 3 이후 |
+| Election 분산 환경 지원 — `on_connect_peer()`에서 `_core/election/#` 추가 구독 | FR-10 | 현재 Election은 단일 브로커 한정 동작 (하단 설계 제약 참고) |
+| Election 성공 시 peer 브로커(Edge 연결 브로커)에 `campus/alert/core_switch` 발행 | FR-10, FR-14 | 현재 자신의 브로커에만 topology 발행 — Edge가 수신 불가 |
 
 #### Edge Broker
 
 | 구성요소 | 관련 FR | 비고 |
 | -------- | ------- | ---- |
-| CT 수신 후 version 비교 → 구버전 무시 | FR-09 | on_message_core에 TODO 주석 |
 | `campus/alert/core_switch` 수신 → 명시적 Backup Core 재연결 | FR-05 | 현재는 LWT 기반으로만 failover |
+| CT 수신 후 `active_core_id` 변경 감지 → 새 Active Core로 명시적 재연결 | FR-05, FR-10 | 현재 CT 적용 후 재연결 로직 없음 |
 | CT 수신 후 인접 Node에 Ping 발송 (RTT 측정 시작) | FR-08 | Phase 3 |
 | Pong 수신 → RTT 계산 + LinkEntry 갱신 | FR-08 | Phase 3 |
 | RTT + hop_to_core 기반 최적 Relay Node 선택 | FR-08 | Phase 3 |
@@ -549,6 +551,45 @@ typedef struct {
 
 ---
 
+### 14.2.1 설계 제약 — Election과 Edge 재연결
+
+#### Election의 단일 브로커 한계
+
+현재 Election 메커니즘은 `on_message()` (자신 브로커 수신)에만 구현되어 있어, **두 Core가 서로 다른 mosquitto 인스턴스를 운영하는 분산 환경에서는 동작하지 않는다.**
+
+```
+실제 분산 환경 (브로커 2개):
+
+  Core A 브로커  ←── Edge들 연결됨
+      ↑
+  Core B (mosq_peer)  ←── TOPIC_CT_SYNC + TOPIC_CORE_WILL_ALL 만 구독
+                           _core/election/# 는 구독 안 함
+      ↓
+  Core B 브로커  ←── Core B 자체 운영
+
+  → Core A 브로커에 _core/election/request 발행해도 Core B는 수신 불가
+```
+
+**테스트(08_election.sh)가 통과되는 이유**: Core A·B가 동일한 mosquitto 인스턴스를 공유하기 때문.
+
+**수정 방향**:
+1. `on_connect_peer()`에서 `TOPIC_ELECTION_ALL` 추가 구독
+2. Election 성공(ACTIVE 전환) 시 `mosq_peer`(Edge들이 연결된 브로커)에도 `campus/alert/core_switch` 발행
+
+#### Election 후 Edge 재연결 부재
+
+Election으로 Core B가 ACTIVE가 되어도, Edge는 새 Active Core의 IP:Port를 알 수 없다.
+
+| 조건 | Edge가 새 Active Core IP:Port를 아는가? |
+|---|---|
+| 단일 브로커 테스트 환경 | ✅ topology 수신, CT의 NodeEntry에 IP:Port 포함 |
+| 실제 2-브로커 환경 (Election 경유) | ❌ election 미전달 + topology가 Core B 브로커에만 발행됨 |
+| 실제 2-브로커 환경 (Active SIGKILL → LWT 경유) | ✅ `campus/alert/core_switch` payload에 `ip:port` 명시, Edge가 `prefer_backup` 전환 |
+
+**결론**: 현재 구현에서 실제 분산 환경의 Core 전환은 **LWT → `core_switch` 경로만 올바르게 동작**한다. Election은 단일 브로커 시나리오 전용이며, 실제 분산 환경 지원을 위해서는 위 수정 방향 적용이 필요하다.
+
+---
+
 ### 14.3 개발 단계별 진행 현황
 
 | Phase | 목표 | 관련 FR | 상태 |
@@ -557,15 +598,39 @@ typedef struct {
 | **2** | Core 장애 대응 + Store-and-Forward | FR-04, FR-05, FR-07, FR-14 | ✅ 완료 |
 | **3** | RTT 측정 + Relay 경로 선택 | FR-08 | ⬜ 미착수 |
 | **4** | Web Client 이벤트 로그 + 토폴로지 그래프 | FR-11, FR-12 | ✅ 완료 |
+| **5** | Core 미완료 항목 (CT version 비교, Node 복구, Election) | FR-01, FR-10, FR-13 | ✅ 완료 |
 
-### 14.4 Phase 3 구현 계획
+### 14.4 Phase 5 구현 완료 항목 (2026-04-17)
+
+#### Core Broker
+
+| 구성요소 | 관련 FR | 구현 위치 |
+| -------- | ------- | --------- |
+| CT 수신 시 version 비교 → 구버전 무시 (`on_message_peer`, `on_message`) | FR-01 | `broker/src/core/main.cpp` |
+| Node 복구(OFFLINE→ONLINE) 감지 → `campus/alert/node_up/<id>` 발행 | FR-13, A-02 | `broker/src/core/main.cpp` |
+| Core Election 메커니즘 — `_core/election/request` 수신 시 ID 비교 투표, `_core/election/result` 집계 후 ACTIVE 전환 | FR-10, C-03, C-04 | `broker/src/core/main.cpp` |
+| `MSG_TYPE_ELECTION_REQUEST` / `ELECTION_RESULT` 타입 및 토픽 상수 추가 | FR-10 | `broker/include/message.h`, `broker/src/common/mqtt_json.cpp` |
+
+#### Edge Broker
+
+| 구성요소 | 관련 FR | 구현 위치 |
+| -------- | ------- | --------- |
+| CT 수신 후 version 비교 → 구버전 무시, 최신 CT를 `ct_manager`에 반영 | FR-01, FR-09 | `broker/src/edge/main.cpp` |
+
+#### 시나리오 테스트
+
+| 스크립트 | 검증 내용 |
+| -------- | --------- |
+| `test/core/07_node_recovery.sh` | Node LWT → OFFLINE → M-03 재발행 → `campus/alert/node_up` 수신 확인 |
+| `test/core/08_election.sh` | `_core/election/request` 발행 → `_core/election/result` 수신 → topology 갱신 확인 |
+
+### 14.5 Phase 3 구현 계획
 
 | 항목 | 위치 | 내용 |
 | ---- | ---- | ---- |
 | Ping 발송 트리거 | `edge/main.cpp` on_message_core (CT 수신 시) | CT의 nodes 순회 → 자신과 다른 NODE 역할 노드에 Ping 발송 |
 | RTT 측정 | `edge/main.cpp` on_message_core (Pong 수신 시) | 발송 시각 기록 → Pong 수신 시각 차이 계산 → ct_manager.updateLinkRtt() |
 | Relay 경로 선택 | 별도 헬퍼 함수 | CT 스냅샷에서 NODE_STATUS_ONLINE 노드 필터 → RTT 최소 선택, RTT 동점 시 hop_to_core 최소 선택 |
-| CT 버전 비교 | `on_message_core`, `on_message_peer` | `received.version <= local.version` 이면 skip |
 
 ---
 

--- a/broker/include/message.h
+++ b/broker/include/message.h
@@ -22,6 +22,8 @@ typedef enum {
     MSG_TYPE_STATUS,
     MSG_TYPE_LWT_CORE,
     MSG_TYPE_LWT_NODE,
+    MSG_TYPE_ELECTION_REQUEST,   /* C-03: 선출 요청 */
+    MSG_TYPE_ELECTION_RESULT,    /* C-04: 선출 결과(투표) */
     MSG_TYPE_UNKNOWN
 } MsgType;
 
@@ -88,6 +90,8 @@ typedef struct {
 #define TOPIC_CT_SYNC          "_core/sync/connection_table"  /* C-01 Active→Backup (retained) */
 #define TOPIC_NODE_REGISTER    "_core/sync/node_register"     /* C-01 Backup→Active node sync  */
 #define TOPIC_ELECTION_ALL     "_core/election/#"             /* C-03/C-04 subscribe */
+#define TOPIC_ELECTION_REQUEST "_core/election/request"       /* C-03: 선출 요청 */
+#define TOPIC_ELECTION_RESULT  "_core/election/result"        /* C-04: 선출 결과(투표) */
 
 // ── MQTT Topics: Edge ─────────────────────────────────────────────────────────
 #define TOPIC_LWT_NODE_PREFIX  "campus/will/node/"            /* W-02 LWT publish prefix */

--- a/broker/src/common/mqtt_json.cpp
+++ b/broker/src/common/mqtt_json.cpp
@@ -34,6 +34,8 @@ static const char* msg_type_str(MsgType t) {
     case MSG_TYPE_STATUS:               return "STATUS";
     case MSG_TYPE_LWT_CORE:             return "LWT_CORE";
     case MSG_TYPE_LWT_NODE:             return "LWT_NODE";
+    case MSG_TYPE_ELECTION_REQUEST:     return "ELECTION_REQ";
+    case MSG_TYPE_ELECTION_RESULT:      return "ELECTION_RES";
     default:                            return "UNKNOWN";
     }
 }
@@ -48,6 +50,8 @@ static MsgType msg_type_from_str(const std::string& s) {
     if (s == "STATUS")          return MSG_TYPE_STATUS;
     if (s == "LWT_CORE")        return MSG_TYPE_LWT_CORE;
     if (s == "LWT_NODE")        return MSG_TYPE_LWT_NODE;
+    if (s == "ELECTION_REQ")    return MSG_TYPE_ELECTION_REQUEST;
+    if (s == "ELECTION_RES")    return MSG_TYPE_ELECTION_RESULT;
     return MSG_TYPE_UNKNOWN;
 }
 

--- a/broker/src/core/main.cpp
+++ b/broker/src/core/main.cpp
@@ -26,6 +26,10 @@ struct CoreContext {
     std::unordered_set<std::string> seen_msg_ids;
     struct mosquitto*               mosq_self;  // own broker connection
     struct mosquitto*               mosq_peer;  // Backup → Active's broker
+
+    // Election state (FR-10)
+    int  election_votes;               // 자신을 지지하는 투표 수
+    char election_winner[UUID_LEN];    // 현재 라운드 최다득표 후보
 };
 
 static void handle_signal(int) { g_running = false; }
@@ -147,9 +151,26 @@ static void on_message(struct mosquitto* mosq, void* userdata,
         node.status = NODE_STATUS_ONLINE;
         node.hop_to_core = 1;
 
-        ctx->ct_manager->addNode(node);
-        on_ct_changed(mosq, ctx);
-        printf("[core] edge registered: %s  %s:%d\n", node.id, node_ip, node_port);
+        auto existing = ctx->ct_manager->findNode(reg.source.id);
+        if (existing && existing->status == NODE_STATUS_OFFLINE) {
+            // Node 복구: OFFLINE → ONLINE (FR-13, A-02)
+            ctx->ct_manager->setNodeStatus(reg.source.id, NODE_STATUS_ONLINE);
+            on_ct_changed(mosq, ctx);
+
+            char alert_topic[128];
+            snprintf(alert_topic, sizeof(alert_topic), "campus/alert/node_up/%s", reg.source.id);
+            ConnectionTable ct = ctx->ct_manager->snapshot();
+            std::string ct_json = connection_table_to_json(ct);
+            mosquitto_publish(mosq, nullptr, alert_topic,
+                (int)ct_json.size(), ct_json.c_str(), 1, false);
+
+            printf("[core] node recovered: %s  (ct.version=%d)\n", reg.source.id, ct.version);
+        } else if (!existing) {
+            ctx->ct_manager->addNode(node);
+            on_ct_changed(mosq, ctx);
+            printf("[core] edge registered: %s  %s:%d\n", node.id, node_ip, node_port);
+        }
+        // else: already ONLINE, ignore duplicate
         return;
     }
 
@@ -158,6 +179,9 @@ static void on_message(struct mosquitto* mosq, void* userdata,
         ConnectionTable remote;
         std::string json(static_cast<char*>(msg->payload), msg->payloadlen);
         if (!connection_table_from_json(json, remote)) return;
+
+        // 구버전 CT 무시 (FR-01)
+        if (remote.version <= ctx->ct_manager->snapshot().version) return;
 
         if (merge_connection_tables(*ctx->ct_manager, remote)) {
             publish_topology(mosq, ctx);
@@ -184,6 +208,59 @@ static void on_message(struct mosquitto* mosq, void* userdata,
         mosquitto_publish(mosq, nullptr, msg->topic,
             msg->payloadlen, msg->payload, 1, false);
         printf("[core] event forwarded: %s  (msg_id=%.8s)\n", msg->topic, evt.msg_id);
+        return;
+    }
+
+    // Election 요청 수신 (C-03): 후보 결정 후 투표 발행 (FR-10)
+    if (strcmp(msg->topic, TOPIC_ELECTION_REQUEST) == 0) {
+        MqttMessage req = {};
+        std::string json(static_cast<char*>(msg->payload), msg->payloadlen);
+        if (!mqtt_message_from_json(json, req)) return;
+
+        // 자신이 보낸 요청은 무시
+        if (strcmp(req.source.id, ctx->core_id) == 0) return;
+
+        // 단순 기준: ID 사전순 비교 (RTT 미구현 시 fallback)
+        const char* candidate = (strcmp(ctx->core_id, req.source.id) < 0)
+            ? ctx->core_id : req.source.id;
+
+        MqttMessage vote = {};
+        uuid_generate(vote.msg_id);
+        vote.type = MSG_TYPE_ELECTION_RESULT;
+        vote.source.role = NODE_ROLE_CORE;
+        strncpy(vote.source.id, ctx->core_id, UUID_LEN - 1);
+        strncpy(vote.payload.description, candidate, DESCRIPTION_LEN - 1);
+
+        std::string vote_json = mqtt_message_to_json(vote);
+        mosquitto_publish(mosq, nullptr, TOPIC_ELECTION_RESULT,
+            (int)vote_json.size(), vote_json.c_str(), 1, false);
+
+        printf("[core] election vote sent: candidate=%s\n", candidate);
+        return;
+    }
+
+    // Election 결과 수신 (C-04): 투표 집계 → 과반 시 ACTIVE 선언 (FR-10)
+    if (strcmp(msg->topic, TOPIC_ELECTION_RESULT) == 0) {
+        MqttMessage res = {};
+        std::string json(static_cast<char*>(msg->payload), msg->payloadlen);
+        if (!mqtt_message_from_json(json, res)) return;
+
+        // 자신이 보낸 투표는 무시
+        if (strcmp(res.source.id, ctx->core_id) == 0) return;
+
+        if (strcmp(res.payload.description, ctx->core_id) == 0) {
+            ctx->election_votes++;
+            printf("[core] election vote received for self (%d votes)\n", ctx->election_votes);
+
+            // 과반 달성 (2-core 환경에서는 1표면 충분)
+            if (ctx->election_votes >= 1) {
+                ctx->ct_manager->setActiveCoreId(ctx->core_id);
+                on_ct_changed(mosq, ctx);
+                ctx->is_backup = false;
+                ctx->election_votes = 0;
+                printf("[core] elected as ACTIVE (election complete)\n");
+            }
+        }
         return;
     }
 }
@@ -220,6 +297,14 @@ static void on_message_peer(struct mosquitto* mosq, void* userdata,
         ConnectionTable remote;
         std::string json(static_cast<char*>(msg->payload), msg->payloadlen);
         if (!connection_table_from_json(json, remote)) return;
+
+        // 구버전 CT 무시 (FR-01)
+        int local_ver = ctx->ct_manager->snapshot().version;
+        if (remote.version <= local_ver) {
+            printf("[core/backup] skip stale CT (remote=%d <= local=%d)\n",
+                remote.version, local_ver);
+            return;
+        }
 
         // Active의 active_core_id 반영
         if (remote.active_core_id[0] != '\0') {

--- a/broker/src/edge/main.cpp
+++ b/broker/src/edge/main.cpp
@@ -49,6 +49,8 @@ struct EdgeContext
     std::deque<QueuedEvent> store_queue;
     std::mutex queue_mutex;
     std::mutex flush_mutex;
+
+    int last_ct_version = 0;  // 마지막 수신한 CT 버전 (구버전 무시용)
 };
 
 static void handle_signal(int) { g_running = false; }
@@ -419,9 +421,23 @@ static void on_message_core(struct mosquitto* mosq, void* userdata,
         std::string json(static_cast<char*>(msg->payload), msg->payloadlen);
         if (connection_table_from_json(json, ct))
         {
-            std::printf("[edge] CT received (version=%d, nodes=%d)\n",
-                ct.version, ct.node_count);
-            // TODO: version 비교 후 구버전 무시, RTT 측정 → relay 경로 초기화
+            if (ct.version <= ctx->last_ct_version)
+            {
+                std::printf("[edge] skip stale CT (remote=%d <= local=%d)\n",
+                    ct.version, ctx->last_ct_version);
+                return;
+            }
+            if (ct.active_core_id[0] != '\0')
+                ctx->ct_manager->setActiveCoreId(ct.active_core_id);
+            for (int i = 0; i < ct.node_count; i++)
+            {
+                if (!ctx->ct_manager->addNode(ct.nodes[i]))
+                    ctx->ct_manager->updateNode(ct.nodes[i]);
+            }
+            for (int i = 0; i < ct.link_count; i++)
+                ctx->ct_manager->addLink(ct.links[i]);
+            ctx->last_ct_version = ct.version;
+            std::printf("[edge] CT applied (version=%d, nodes=%d)\n", ct.version, ct.node_count);
         }
         return;
     }

--- a/test/core/07_node_recovery.sh
+++ b/test/core/07_node_recovery.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# CORE-07: Node 복구 감지 → campus/alert/node_up 발행 검증 (FR-13, A-02, 시나리오 5.5)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+source "$SCRIPT_DIR/../lib/payloads.sh"
+
+require_mqtt_tools
+make_run_dir "core-node-recovery" >/dev/null
+setup_cleanup_trap
+
+sub_log="$TEST_RUN_DIR/subscriber.log"
+core_log="$TEST_RUN_DIR/core.log"
+
+node_id="$NODE_1_ID"
+
+start_subscriber "$sub_log" \
+  "campus/monitor/topology" \
+  "campus/alert/node_down/#" \
+  "campus/alert/node_up/#" >/dev/null
+sleep 1
+
+start_core "$core_log" >/dev/null
+if ! wait_for_pattern "$core_log" '\[core\] connected' 10; then
+  show_file_tail "$core_log"
+  die "core did not connect to broker"
+fi
+
+# M-03: 노드 등록
+reg_payload="$(emit_status_json "NODE" "$node_id" "CORE" "" "127.0.0.1:1883" "" "" "$(gen_uuid)")"
+mqtt_publish_json "campus/monitor/status/$node_id" 1 false "$reg_payload"
+
+if ! wait_for_pattern "$core_log" "edge registered: $node_id" 10; then
+  show_file_tail "$core_log"
+  die "core did not register node $node_id"
+fi
+
+# W-02: 노드 LWT (OFFLINE)
+lwt_payload="$(emit_status_json "NODE" "$node_id" "CORE" "" "" "" "" "$(gen_uuid)")"
+mqtt_publish_json "campus/will/node/$node_id" 1 false "$lwt_payload"
+
+if ! wait_for_pattern "$sub_log" "campus/alert/node_down/$node_id" 10; then
+  show_file_tail "$sub_log"
+  die "node_down alert was not published for $node_id"
+fi
+
+if ! wait_for_pattern "$core_log" "node offline: $node_id" 10; then
+  show_file_tail "$core_log"
+  die "core did not mark node offline"
+fi
+
+# M-03 재발행: 노드 복구 시뮬레이션
+sleep 0.5
+reg_payload2="$(emit_status_json "NODE" "$node_id" "CORE" "" "127.0.0.1:1883" "" "" "$(gen_uuid)")"
+mqtt_publish_json "campus/monitor/status/$node_id" 1 false "$reg_payload2"
+
+if ! wait_for_pattern "$sub_log" "campus/alert/node_up/$node_id" 10; then
+  show_file_tail "$sub_log"
+  die "node_up alert was not published for $node_id"
+fi
+
+if ! wait_for_pattern "$sub_log" 'ONLINE' 10; then
+  show_file_tail "$sub_log"
+  die "node_up alert payload does not contain ONLINE status"
+fi
+
+log "node recovery ok: node_id=$node_id"
+log "logs kept in $TEST_RUN_DIR until script exit"

--- a/test/core/08_election.sh
+++ b/test/core/08_election.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# CORE-08: Core Election 메커니즘 검증 (FR-10, C-03, C-04)
+# Core A가 election request 발행 → Core B가 투표 → 승자의 CT에 active_core_id 반영
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+source "$SCRIPT_DIR/../lib/payloads.sh"
+
+require_mqtt_tools
+make_run_dir "core-election" >/dev/null
+setup_cleanup_trap
+
+sub_log="$TEST_RUN_DIR/subscriber.log"
+core_a_log="$TEST_RUN_DIR/core_a.log"
+core_b_log="$TEST_RUN_DIR/core_b.log"
+
+start_standalone_core() {
+  local log_file="$1"
+  local binary
+  binary="$(core_binary)"
+  "$binary" "$MQTT_HOST" "$MQTT_PORT" >"$log_file" 2>&1 &
+  register_pid "$!"
+  printf '%s\n' "$!"
+}
+
+start_subscriber "$sub_log" \
+  "_core/election/#" \
+  "campus/monitor/topology" >/dev/null
+sleep 1
+
+# Core A 기동
+start_standalone_core "$core_a_log" >/dev/null
+if ! wait_for_pattern "$core_a_log" '\[core\] connected' 10; then
+  show_file_tail "$core_a_log"
+  die "core A did not connect"
+fi
+core_a_id="$(extract_core_id "$core_a_log")"
+
+# Core B 기동
+start_standalone_core "$core_b_log" >/dev/null
+if ! wait_for_pattern "$core_b_log" '\[core\] connected' 10; then
+  show_file_tail "$core_b_log"
+  die "core B did not connect"
+fi
+core_b_id="$(extract_core_id "$core_b_log")"
+
+sleep 0.5
+
+# election request 발행 (Core A가 요청하는 것처럼 시뮬레이션)
+req_payload="$(cat <<EOF
+{
+  "msg_id": "$(gen_uuid)",
+  "type": "ELECTION_REQ",
+  "timestamp": "$(iso_timestamp)",
+  "source": {"role": "CORE", "id": "$core_a_id"},
+  "target": {"role": "CORE", "id": "all"},
+  "route": {"original_node": "$core_a_id", "prev_hop": "$core_a_id", "next_hop": "all", "hop_count": 0, "ttl": 1},
+  "delivery": {"qos": 1, "dup": false, "retain": false},
+  "payload": {"building_id": "", "camera_id": "", "description": "$core_a_id"}
+}
+EOF
+)"
+mqtt_publish_json "_core/election/request" 1 false "$req_payload"
+
+# election result (_core/election/result) 발행 확인
+if ! wait_for_pattern "$sub_log" '_core/election/result' 10; then
+  show_file_tail "$sub_log"
+  die "election result was not published"
+fi
+
+# topology에 active_core_id가 반영되었는지 확인
+if ! wait_for_pattern "$sub_log" 'campus/monitor/topology' 10; then
+  show_file_tail "$sub_log"
+  die "topology was not updated after election"
+fi
+
+log "election ok: core_a_id=$core_a_id, core_b_id=$core_b_id"
+log "election result published and topology updated"
+log "logs kept in $TEST_RUN_DIR until script exit"

--- a/test/test_pub.sh
+++ b/test/test_pub.sh
@@ -31,6 +31,8 @@ Usage: ./test/test_pub.sh <case>
   core_event_dedup
   core_ct_sync
   core_core_switch
+  core_node_recovery
+  core_election
 
 [edge] edge_broker 동작 검증 (BUILD_DIR 또는 EDGE_BINARY 필요):
   edge_ping_pong
@@ -74,6 +76,8 @@ core/node_offline
 core/event_dedup
 core/ct_sync
 core/core_switch
+core/node_recovery
+core/election
 edge/ping_pong
 edge/lwt
 EOF
@@ -116,6 +120,8 @@ run_all_core() {
   try_run_binary_test "$SCRIPT_DIR/core/04_event_dedup.sh"  "core/04_event_dedup"
   try_run_binary_test "$SCRIPT_DIR/core/05_ct_sync.sh"      "core/05_ct_sync"
   try_run_binary_test "$SCRIPT_DIR/core/06_core_switch.sh"  "core/06_core_switch"
+  try_run_binary_test "$SCRIPT_DIR/core/07_node_recovery.sh" "core/07_node_recovery"
+  try_run_binary_test "$SCRIPT_DIR/core/08_election.sh"      "core/08_election"
   printf '[test] all_core completed\n'
 }
 
@@ -147,7 +153,9 @@ case "${1:-help}" in
   core_node_offline)  exec "$SCRIPT_DIR/core/03_node_offline.sh" ;;
   core_event_dedup)   exec "$SCRIPT_DIR/core/04_event_dedup.sh" ;;
   core_ct_sync)       exec "$SCRIPT_DIR/core/05_ct_sync.sh" ;;
-  core_core_switch)   exec "$SCRIPT_DIR/core/06_core_switch.sh" ;;
+  core_core_switch)     exec "$SCRIPT_DIR/core/06_core_switch.sh" ;;
+  core_node_recovery)  exec "$SCRIPT_DIR/core/07_node_recovery.sh" ;;
+  core_election)       exec "$SCRIPT_DIR/core/08_election.sh" ;;
   # edge
   edge_ping_pong)     exec "$SCRIPT_DIR/edge/01_ping_pong.sh" ;;
   edge_lwt)           exec "$SCRIPT_DIR/edge/02_lwt.sh" ;;


### PR DESCRIPTION
- core: CT version 비교 — on_message/on_message_peer 구버전 수신 시 skip
- core: Node 복구(OFFLINE→ONLINE) 감지 → campus/alert/node_up/<id> 발행
- core: Core Election 메커니즘 — election/request 투표, result 집계 후 ACTIVE 전환
- core: MSG_TYPE_ELECTION_REQUEST/RESULT 타입 및 토픽 상수 추가
- edge: CT 수신 시 version 비교 → 구버전 무시, ct_manager 반영
- test: 07_node_recovery.sh, 08_election.sh 추가
- PRD: 14.2 미완료 항목 갱신, Election 단일 브로커 한계 및 Edge 재연결 부재 설계 제약 문서화